### PR TITLE
Allow C14 net to be loaded during initialization and destroyed during cleanup

### DIFF
--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -7,9 +7,17 @@ module advance_xp2_xpyp_module
   ! Contains the subroutine advance_xp2_xpyp and ancillary functions.
   !-----------------------------------------------------------------------
 
+  use ftorch, only: &
+    torch_kCPU, &  ! --------------- Type(s)
+    torch_model, &
+    torch_model_load, &  ! --------- Procedure(s)
+    torch_delete
+
   implicit none
 
-  public :: advance_xp2_xpyp, &
+  public :: setup_C14_ML_xp2_xpyp, &
+            clean_up_C14_ML_xp2_xpyp, &
+            advance_xp2_xpyp, &
             update_xp2_mc
 
   private :: xp2_xpyp_lhs, & 
@@ -44,7 +52,50 @@ module advance_xp2_xpyp_module
     ndiags3 = 3,  &
     ndiags5 = 5
 
+  type(torch_model) :: C14_neural_net
+
   contains
+
+  subroutine setup_C14_ML_xp2_xpyp( c14_net_filepath )
+    ! Description:
+    ! If using the C14 Machine Learnt scheme load the net as a module variable during
+    ! startup before CLUBB starts timestepping loop.
+
+    ! Added by Jack Atkinson <jwa34@cam.ac.uk> of ICCS Feb 2026
+    !-----------------------------------------------------------------------
+
+    use constants_clubb, only:  &
+      fstdout
+
+    implicit none
+
+    character(len=100), intent(in) :: &
+      c14_net_filepath  ! Filepath to the C14 neural net
+
+    write(unit=fstdout, fmt='(a,a)') "Reading NN from: ", c14_net_filepath
+
+    call torch_model_load(C14_neural_net, c14_net_filepath, torch_kCPU)
+
+  end subroutine setup_C14_ML_xp2_xpyp
+
+  subroutine clean_up_C14_ML_xp2_xpyp()
+    ! Description:
+    ! If using the C14 Machine Learnt scheme destroy the net as a module variable during
+    ! CLUBB clean up after timestepping loop.
+
+    ! Added by Jack Atkinson <jwa34@cam.ac.uk> of ICCS Feb 2026
+    !-----------------------------------------------------------------------
+
+    use constants_clubb, only:  &
+      fstdout
+
+    implicit none
+
+    write(unit=fstdout, fmt='(a)') "Deleting NN"
+
+    call torch_delete( C14_neural_net )
+
+  end subroutine clean_up_C14_ML_xp2_xpyp
 
   !=============================================================================
   subroutine advance_xp2_xpyp( nzm, nzt, ngrdcol, sclr_dim, sclr_tol, gr, sclr_idx,& ! In

--- a/src/clubb_driver.F90
+++ b/src/clubb_driver.F90
@@ -892,6 +892,9 @@ module clubb_driver
       setup_gr_fixed_min, &
       setup_gr_dycore
 
+    use advance_xp2_xpyp_module, only: &
+      setup_C14_ML_xp2_xpyp   !------------------------------------------ Procedure(s)
+
     implicit none
 
     character(len=*), intent(in) :: &
@@ -2669,6 +2672,11 @@ module clubb_driver
     
     call set_case_initial_conditions(ngrdcol, clubb_params, err_info)
 
+    ! If using the ML scheme for C14 in advance_xp2_xpyp load the Neural Net
+    if ( clubb_config_flags%l_c14_ml ) then
+      call setup_C14_ML_xp2_xpyp( clubb_config_flags%c14_ml_net_filepath )
+    end if
+
   end subroutine init_clubb_case
 
   !=============================================================================================
@@ -4275,6 +4283,9 @@ module clubb_driver
         cleanup_latin_hypercube_arrays !------------------ Procedure(s)
 #endif
 
+    use advance_xp2_xpyp_module, only: &
+      clean_up_C14_ML_xp2_xpyp   !--------------------------------------- Procedure(s)
+
     implicit none
 
     integer, intent(in) :: &
@@ -4664,6 +4675,11 @@ module clubb_driver
               Nccnm_init, &
               sclrm_init, &
               edsclrm_init )
+
+    ! If using the ML scheme for C14 in advance_xp2_xpyp clean up the Neural Net
+    if ( clubb_config_flags%l_c14_ml ) then
+      call clean_up_C14_ML_xp2_xpyp()
+    end if
 
   end subroutine clean_up_clubb
 


### PR DESCRIPTION
Replaces #24 after merging of #21 and #23 by cherry-picking the relevant commit.