### PR TITLE
add C14 parameter to standard output

### DIFF
--- a/input/stats/standard_stats.in
+++ b/input/stats/standard_stats.in
@@ -171,7 +171,7 @@ vars_zm =
 'rtpthlp_bt', 'rtpthlp_ma', 'rtpthlp_ta', 'rtpthlp_tp1', 'rtpthlp_tp2',
 'rtpthlp_dp1', 'rtpthlp_dp2', 'rtpthlp_cl', 'rtpthlp_sf', 'rtpthlp_forcing', 'rtpthlp_mc',
 'wpthlp_enter_mfl', 'wpthlp_exit_mfl', 'wprtp_enter_mfl', 'wprtp_exit_mfl',
-'wpthlp_mfl_min', 'wpthlp_mfl_max', 'wprtp_mfl_min', 'wprtp_mfl_max',
+'wpthlp_mfl_min', 'wpthlp_mfl_max', 'wprtp_mfl_min', 'wprtp_mfl_max', 'C14',
 
 
 'stability_correction',

--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -636,6 +636,13 @@ module advance_xp2_xpyp_module
 
     endif ! l_c14_ml
     
+    ! Write the value of C14 to output on zm grid
+    if ( stats_metadata%l_stats_samp ) then
+      do i = 1, ngrdcol
+        call stat_update_var( stats_metadata%iC14, C14_1d(i,:), stats_zm(i) )
+      end do
+    end if
+
     ! Are we solving for passive scalars as well?
     if ( sclr_dim > 0 ) then
       l_scalar_calc = .true.

--- a/src/CLUBB_core/stats_variables.F90
+++ b/src/CLUBB_core/stats_variables.F90
@@ -1154,6 +1154,9 @@ module stats_variables
       ibrunt_term_time_avg = 0,   & ! the time averaged Lscale term of the grid density
       inorm_min_grid_dens = 0,     & ! the brunt-vaisala term of the grid density
       inorm_grid_dens = 0            ! the brunt-vaisala term of the grid density
+    
+    integer :: &
+      iC14 = 0 ! Index for C14 parameter, relevant for CLUBB_ML
 
 
     !====================================================================

--- a/src/CLUBB_core/stats_zm_module.F90
+++ b/src/CLUBB_core/stats_zm_module.F90
@@ -2539,6 +2539,13 @@ module stats_zm_module
             l_silhs=.false., grid_kind=stats_zm )
           k = k + 1
         end do
+      
+      case ( 'C14' ) ! Add output for C14, relevant for CLUBB_ML
+        stats_metadata%iC14 = k
+        call stat_assign( var_index=stats_metadata%iC14, var_name="C14", &
+            var_description="C_14 parameter", var_units="-", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
 
       case default
         write(fstderr,*) 'Error:  unrecognized variable in vars_zm:  ',  trim(vars_zm(i))


### PR DESCRIPTION
Addresses #37 and adds the C14 parameter to the standard output. I've tested this using the BOMEX standalone case with and without ML:

<img width="600" height="422" alt="image" src="https://github.com/user-attachments/assets/304ba8d1-36ae-40c7-a6b1-efda9c354bb8" />