### PR TITLE
Add simple C14 evaluation cumulative timer

### DIFF
--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -15,6 +15,8 @@ module advance_xp2_xpyp_module
     torch_model_load, &
     torch_model_forward, &
     torch_delete
+  use code_timer_module, only: &
+    timer_t, timer_start, timer_stop
 
   implicit none
 
@@ -56,6 +58,9 @@ module advance_xp2_xpyp_module
     ndiags5 = 5
 
   type(torch_model) :: C14_neural_net
+  ! Global thread-unsafe timer for measuring the cumulative execution time of C14
+  ! evaluation
+  type(timer_t) :: C14_timer_total
 
   contains
 
@@ -79,6 +84,9 @@ module advance_xp2_xpyp_module
 
     call torch_model_load(C14_neural_net, c14_net_filepath, torch_kCPU)
 
+    ! Initialise timer
+    C14_timer_total = timer_t()
+
   end subroutine setup_C14_ML_xp2_xpyp
 
   subroutine clean_up_C14_ML_xp2_xpyp()
@@ -97,6 +105,9 @@ module advance_xp2_xpyp_module
     write(unit=fstdout, fmt='(a)') "Deleting NN"
 
     call torch_delete( C14_neural_net )
+
+    ! Print the time
+    write(unit=fstdout, fmt='(a,g,a)') "C14 total evaluation time: ", C14_timer_total % time_elapsed, " [s]"
 
   end subroutine clean_up_C14_ML_xp2_xpyp
 
@@ -607,7 +618,7 @@ module advance_xp2_xpyp_module
     ! Once this is working we can move towards batching a column at a time or multiple
     ! columns at once.
     if ( l_c14_ml ) then
-
+      call timer_start(C14_timer_total)
       ! Interpolate Lscales from thermal to momentum grid
       Lscale_up_zm(:,:) = zt2zm_api( nzm, nzt, ngrdcol, gr, Lscale_up(:,:), zero_threshold )
       Lscale_down_zm(:,:) = zt2zm_api( nzm, nzt, ngrdcol, gr, Lscale_down(:,:), zero_threshold )
@@ -633,7 +644,7 @@ module advance_xp2_xpyp_module
           C14_1d(i,k) = one_third * c14_ml_output(1)
         end do
       end do
-
+      call timer_stop(C14_timer_total)
     endif ! l_c14_ml
     
     ! Are we solving for passive scalars as well?

--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -61,6 +61,8 @@ module advance_xp2_xpyp_module
   ! Global thread-unsafe timer for measuring the cumulative execution time of C14
   ! evaluation
   type(timer_t) :: C14_timer_total
+  ! Timer for the classical 'constant' assignment of the C14
+  type(timer_t) :: C14_timer_no_ml
 
   contains
 
@@ -92,6 +94,7 @@ module advance_xp2_xpyp_module
 
     ! Initialise timer
     C14_timer_total = timer_t()
+    C14_timer_no_ml = timer_t()
 
   end subroutine setup_C14_ML_xp2_xpyp
 
@@ -114,6 +117,7 @@ module advance_xp2_xpyp_module
 
     ! Print the time
     write(unit=fstdout, fmt='(a,g,a)') "C14 total evaluation time: ", C14_timer_total % time_elapsed, " [s]"
+    write(unit=fstdout, fmt='(a,g,a)') "C14 no ML time: ", C14_timer_no_ml % time_elapsed, " [s]"
 
   end subroutine clean_up_C14_ML_xp2_xpyp
 
@@ -609,6 +613,7 @@ module advance_xp2_xpyp_module
       !$acc end parallel loop
     endif ! l_C2_cloud_frac
 
+    call timer_start(C14_timer_no_ml)
     !$acc parallel loop gang vector collapse(2) default(present)
     do k = 1, nzm
       do i = 1, ngrdcol
@@ -618,6 +623,7 @@ module advance_xp2_xpyp_module
       end do
     end do
     !$acc end parallel loop
+    call timer_stop(C14_timer_no_ml)
 
     ! ML scheme for C14
     ! Currently performed in a loop one cell at a time.

--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -79,10 +79,16 @@ module advance_xp2_xpyp_module
 
     character(len=100), intent(in) :: &
       c14_net_filepath  ! Filepath to the C14 neural net
+    type(timer_t) :: load_timer
 
     write(unit=fstdout, fmt='(a,a)') "Reading NN from: ", c14_net_filepath
 
+    call timer_start(load_timer)
     call torch_model_load(C14_neural_net, c14_net_filepath, torch_kCPU)
+    call timer_stop(load_timer)
+
+    ! Print the load time
+    write(unit=fstdout, fmt='(a,g,a)') "C14 NN load time: ", load_timer % time_elapsed, " [s]"
 
     ! Initialise timer
     C14_timer_total = timer_t()

--- a/src/CLUBB_core/code_timer_module.F90
+++ b/src/CLUBB_core/code_timer_module.F90
@@ -11,8 +11,8 @@ module code_timer_module
 
   ! A timer!!
   type timer_t
-    real :: time_elapsed        ! Time elapsed [sec]
-    real :: secstart            ! Timer starting time
+    real :: time_elapsed = 0.0       ! Time elapsed [sec]
+    real :: secstart  = 0.0          ! Timer starting time
   end type timer_t
 
   public :: timer_t, timer_start, timer_stop


### PR DESCRIPTION
Closes #36

Use existing timer type but fix the uninitialised components.

The timer lifetime and output is tied to the model. When the model is loaded, the timer resets. When model is deconstructed, the measurement is printed to STDOUT.

Note that the timer may have somewhat high overhead (it is processor dependent but on Linux and with gfortran involves a syscall to getrusage). Hence it is unsuitable to be used inside the 'hot loop'. It should be good enough though to get a rough estimate of the time taken by the whole inference loop.

The 'null' mesurment using the timer (i.e. `timer_end` immediately after `timer_start`) gives a total of ~1ms when the measurement of the total inference time is around 0.5s. 

I was hesitating a bit if the output to STDOUT is sufficient (or if we should print to a dedicated  output file) but in the end you get something like: 
```
...
iteration =      359; time =    21540.0
iteration =      360; time =    21600.0
CLUBB-TIMER time_loop_init =             0.0066
CLUBB-TIMER time_clubb_advance =         0.7282
CLUBB-TIMER time_clubb_pdf =             0.0004
CLUBB-TIMER time_SILHS =                 0.0002
CLUBB-TIMER time_microphys_scheme =      0.0000
CLUBB-TIMER time_microphys_advance =     0.0000
CLUBB-TIMER time_loop_end =              0.8235
CLUBB-TIMER time_output_multi_col =      0.0002
CLUBB-TIMER time_adapt_grid =            0.0000
CLUBB-TIMER time_total =                 1.5610
Deleting NN
C14 total evaluation time:    .5273405     [s]
 Program exited normally
```  
which is nice. 

What is worrying is that we are dealing with non-trivial overhead! 1/3 of the runtime is C14 evaluation! At least for the BOMEX. :crossed_fingers: it will get better with batching or larger problems.  