### PR TITLE
Use CESM FTorch interface module when in CAM

### DIFF
--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -7,7 +7,16 @@ module advance_xp2_xpyp_module
   ! Contains the subroutine advance_xp2_xpyp and ancillary functions.
   !-----------------------------------------------------------------------
 
-  use ftorch, only: &
+! If used in CESM, FTorch needs to be used via the special interface module that
+! wraps its API. If used in standalone CLUBB, the ftorch is used directly
+! Hence we need to conditionally select the right module name for FTorch
+#ifdef CLUBB_CAM
+  #define FTORCH_MODULE FTorch_cesm_interface
+#else
+  #define FTORCH_MODULE ftorch
+#endif
+
+  use FTORCH_MODULE, only: &
     torch_kCPU, &  ! --------------- Type(s)
     torch_tensor, &
     torch_model, &


### PR DESCRIPTION
@jatkinson1000 @vopikamm 

I hope we can merge this one quickly so we can get the `clubb_4ncar_with_ml` branch up to date 'main' branch for further development. 

This one is just a quick solution around the 'FTroch interface problem' in CESM. 

The `CLUBB_CAM` is defined in CESM run. I have verified by building standalone and inside CESM.

Closes https://github.com/m2lines/clubb_ML/issues/52