### PR TITLE
Add up2, vp2, wp2, Lscale_up, Lscale_down output

### DIFF
--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -431,7 +431,9 @@ module advance_xp2_xpyp_module
       sclrpthlp_old    ! Saved value of <sclr'thl'>   [units vary]
     
     real( kind = core_rknd ) :: & 
-      em_infer, &  ! TKE used for ML inference  [m^2/s^2]
+      em_infer     ! TKE used for ML inference  [m^2/s^2]
+
+    real( kind = core_rknd ), dimension(ngrdcol,nzm) :: &   
       up2_infer, & ! ensure non-negative u variance for ML inference [m^2/s^2]
       vp2_infer, & ! ensure non-negative v variance for ML inference [m^2/s^2]
       wp2_infer    ! ensure non-negative w variance for ML inference [m^2/s^2]
@@ -679,15 +681,15 @@ module advance_xp2_xpyp_module
       do k = 1, nzm
         do i = 1, ngrdcol
           ! Protect ML inputs from small negative variances due to round-off.
-          up2_infer = max( up2(i,k), zero )
-          vp2_infer = max( vp2(i,k), zero )
-          wp2_infer = max( wp2(i,k), zero )
+          up2_infer(i,k) = max( up2(i,k), zero )
+          vp2_infer(i,k) = max( vp2(i,k), zero )
+          wp2_infer(i,k) = max( wp2(i,k), zero )
           
           ! Compute TKE at inference time so the ML normalization uses the same
           ! up2/vp2/wp2 values that are passed to the network at k=1. This avoids 
           ! an inconsistency introduced when calc_sfc_varnce updates the surface variances
           ! without updating em. 
-          em_infer = one_half * ( up2_infer + vp2_infer + wp2_infer )
+          em_infer = one_half * ( up2_infer(i,k) + vp2_infer(i,k) + wp2_infer(i,k) )
 
           ! em_infer == zero implies up2, vp2, wp2 are all zero. Setting to one to avoid 
           ! division by zero. The ML input remains zero in this case.
@@ -695,9 +697,9 @@ module advance_xp2_xpyp_module
             em_infer = one
           end if
 
-          c14_ml_input((k-1) * ngrdcol + i, 1) = up2_infer / em_infer
-          c14_ml_input((k-1) * ngrdcol + i, 2) = vp2_infer / em_infer
-          c14_ml_input((k-1) * ngrdcol + i, 3) = wp2_infer / em_infer
+          c14_ml_input((k-1) * ngrdcol + i, 1) = up2_infer(i,k) / em_infer
+          c14_ml_input((k-1) * ngrdcol + i, 2) = vp2_infer(i,k) / em_infer
+          c14_ml_input((k-1) * ngrdcol + i, 3) = wp2_infer(i,k) / em_infer
           c14_ml_input((k-1) * ngrdcol + i, 4) = Lscale_up_zm(i,k) / 1000.0_core_rknd  ! Normalised by 1km per training
           c14_ml_input((k-1) * ngrdcol + i, 5) = Lscale_down_zm(i,k) / 1000.0_core_rknd  ! Normalised by 1km per training
         end do
@@ -723,6 +725,17 @@ module advance_xp2_xpyp_module
       end do
 
       call timer_stop(C14_timer_total)
+
+      ! Write the model inputs to the stats struct for diagnostics
+      if ( stats_metadata%l_stats_samp ) then
+        do i = 1, ngrdcol
+          call stat_update_var( stats_metadata%iup2_infer, up2_infer(i,:), stats_zm(i) )
+          call stat_update_var( stats_metadata%ivp2_infer, vp2_infer(i,:), stats_zm(i) )
+          call stat_update_var( stats_metadata%iwp2_infer, wp2_infer(i,:), stats_zm(i) )
+          call stat_update_var( stats_metadata%iLscale_up_zm, Lscale_up_zm(i,:), stats_zm(i) )
+          call stat_update_var( stats_metadata%iLscale_down_zm, Lscale_down_zm(i,:), stats_zm(i) )
+        end do
+      end if
     endif ! l_c14_ml
     
     ! Write the value of C14 to output on zm grid

--- a/src/CLUBB_core/advance_xp2_xpyp_module.F90
+++ b/src/CLUBB_core/advance_xp2_xpyp_module.F90
@@ -190,6 +190,7 @@ module advance_xp2_xpyp_module
         max_mag_correlation_flux, &
         cloud_frac_min, &
         fstderr, &
+        three, &
         two, &
         one, &
         two_thirds, &
@@ -741,7 +742,7 @@ module advance_xp2_xpyp_module
     ! Write the value of C14 to output on zm grid
     if ( stats_metadata%l_stats_samp ) then
       do i = 1, ngrdcol
-        call stat_update_var( stats_metadata%iC14, C14_1d(i,:), stats_zm(i) )
+        call stat_update_var( stats_metadata%iC14, three * C14_1d(i,:), stats_zm(i) )
       end do
     end if
 

--- a/src/CLUBB_core/stats_variables.F90
+++ b/src/CLUBB_core/stats_variables.F90
@@ -1156,7 +1156,13 @@ module stats_variables
       inorm_grid_dens = 0            ! the brunt-vaisala term of the grid density
     
     integer :: &
-      iC14 = 0 ! Index for C14 parameter, relevant for CLUBB_ML
+      iC14 = 0, & ! Index for C14 parameter, relevant for CLUBB_ML
+      iup2_infer = 0, & ! Index for up2 at inference time, relevant for CLUBB_ML
+      ivp2_infer = 0, & ! Index for vp2 at inference time, relevant for CLUBB_ML
+      iwp2_infer = 0, & ! Index for wp2 at inference time, relevant for CLUBB_ML
+      iLscale_down_zm = 0, & ! Index for Lscale_down on momentum grid, relevant for CLUBB_ML
+      iLscale_up_zm = 0 ! Index for Lscale_up on momentum grid, relevant for CLUBB_ML
+
 
 
     !====================================================================

--- a/src/CLUBB_core/stats_zm_module.F90
+++ b/src/CLUBB_core/stats_zm_module.F90
@@ -2634,6 +2634,41 @@ module stats_zm_module
             var_description="C_14 parameter", var_units="-", &
             l_silhs=.false., grid_kind=stats_zm )
         k = k + 1
+      
+      case ( 'up2_infer' ) ! Add output for up2 at inference time, relevant for CLUBB_ML
+        stats_metadata%iup2_infer = k
+        call stat_assign( var_index=stats_metadata%iup2_infer, var_name="up2_infer", &
+            var_description="u'^2, Variance of eastward (u) wind at CLUBB_ML inference", var_units="m^2/s^2", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
+      
+      case ( 'vp2_infer' ) ! Add output for vp2 at inference time, relevant for CLUBB_ML
+        stats_metadata%ivp2_infer = k
+        call stat_assign( var_index=stats_metadata%ivp2_infer, var_name="vp2_infer", &
+            var_description="v'^2, Variance of northward (v) wind at CLUBB_ML inference", var_units="m^2/s^2", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
+      
+      case ( 'wp2_infer' ) ! Add output for wp2 at inference time, relevant for CLUBB_ML
+        stats_metadata%iwp2_infer = k
+        call stat_assign( var_index=stats_metadata%iwp2_infer, var_name="wp2_infer", &
+            var_description="w'^2, Variance of vertical (w) wind at CLUBB_ML inference", var_units="m^2/s^2", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
+
+      case ( 'Lscale_up_zm' ) ! Add output for Lscale_up, relevant for CLUBB_ML
+        stats_metadata%iLscale_up_zm = k
+        call stat_assign( var_index=stats_metadata%iLscale_up_zm, var_name="Lscale_up_zm", &
+            var_description="Lscale_up, Upward mixing length on momentum grid", var_units="m", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
+
+      case ( 'Lscale_down_zm' ) ! Add output for Lscale_down, relevant for CLUBB_ML
+        stats_metadata%iLscale_down_zm = k
+        call stat_assign( var_index=stats_metadata%iLscale_down_zm, var_name="Lscale_down_zm", &
+            var_description="Lscale_down, Downward mixing length on momentum grid", var_units="m", &
+            l_silhs=.false., grid_kind=stats_zm )
+        k = k + 1
 
       case default
         write(fstderr,*) 'Error:  unrecognized variable in vars_zm:  ',  trim(vars_zm(i))


### PR DESCRIPTION
Addresses #58. The variables mentioned in https://github.com/m2lines/clubb_ML/issues/58#issuecomment-4545028131 are now available as output in CLUBB.

After first trying to wire the fields to CAM via the API, loading them to the CAM physics buffer (this is how it is done for all default CLUBB variables), I found that any CLUBB standalone output can be written to CAM output automatically:

https://github.com/m2lines/CAM-ML/blob/6e061c275416cb77ea6195c3d7b3b22c17cf7bb7/src/physics/cam/clubb_intr.F90#L5007-L5014

The variables need to be specified as `clubb_vars_zm` in `user_nl_cam`, for example I could output them with this namelist:

```fortran
clubb_l_c14_ml = .true.
clubb_c14_ml_net_filepath = "/path/to/CLUBB_nets/C14_allLES.pt"

! clubb_history to make clubb output available, history_clubb to output default CLUBB variables
clubb_history = .true.
history_clubb = .false.

! need to declare desired CLUBB output variables in namelist
clubb_vars_zm = 'C14', 'up2_infer', 'vp2_infer', 'wp2_infer', 'Lscale_up_zm', 'Lscale_down_zm'

! "field include in stream 1? --> I stands for instantaneous (A average)"
fincl1 = 'C14:I', 'up2_infer:I', 'vp2_infer:I', 'wp2_infer:I', 'Lscale_up_zm:I', 'Lscale_down_zm:I'

! Output frequency
nhtfrq = 2
```

The advantage is that we have the variables also available as CLUBB standalone output and don't need to change any code in CAM.